### PR TITLE
Set up Dockerfile for Flask application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM kalilinux/kali-rolling
+RUN apt update && apt install -y python3-flask postgresql-client
+COPY . /app
+WORKDIR /app
+CMD ["python3", "app.py"]


### PR DESCRIPTION
This pull request introduces a new `Dockerfile` to containerize the application using a Kali Linux base image. The Dockerfile sets up the environment by installing necessary dependencies, copying the application code, and specifying the startup command.

Containerization and environment setup:

* Added a new `Dockerfile` that uses `kalilinux/kali-rolling` as the base image, installs `python3-flask` and `postgresql-client`, copies the application code to `/app`, sets the working directory, and defines the default command to run `app.py` with Python 3.