### PR TITLE
Fix verification workflow permissions and extend Copilot guide

### DIFF
--- a/.github/workflows/verification-integrity.yml
+++ b/.github/workflows/verification-integrity.yml
@@ -9,6 +9,8 @@ on:
 permissions:
   contents: read
   security-events: write  # Required for upload-sarif
+  pull-requests: write
+  issues: write
 
 jobs:
   verify:
@@ -93,6 +95,8 @@ jobs:
       - name: Comment PR with results
         if: github.event_name == 'pull_request' && always()
         uses: actions/github-script@v7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary
- grant the verification integrity workflow permissions to comment on pull requests using the default GITHUB_TOKEN
- document the required permissions and verification follow-up guidance in the Copilot & Codex configuration guide, including troubleshooting for 403 integration errors

## Testing
- not run (documentation and workflow updates only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6907b005d0e083329b5359d675f9b087)